### PR TITLE
Feature/verbose mode

### DIFF
--- a/nclint.py
+++ b/nclint.py
@@ -444,5 +444,10 @@ if __name__ == '__main__':
         nc = netCDF4.Dataset(file_, 'r')
         for check in checks:
             if check(nc):
-                print(file_)
-                break
+                if args.verbose:
+                    print('{} FAILED {}'.format(file_, check.__name__))
+                else:
+                    print(file_)
+                    # In non-verbose mode, we only care whether a file is
+                    # good/bad. If it fails, skip the rest of the checks
+                    break

--- a/nclint.py
+++ b/nclint.py
@@ -418,11 +418,20 @@ if __name__ == '__main__':
     parser.add_argument('-l', '--list_checks', action='store_true',
             help='List the names of all available checks and exit',
             default=False)
+    parser.add_argument('-v', '--verbose', action='store_true',
+            help='Provide more detail about available checks and check failures',
+            default=False)
 
     args = parser.parse_args()
 
     if args.list_checks:
-        print("Available checks:", ','.join(check_list))
+        if args.verbose:
+            for check_name in check_list:
+                check = globals()[check_name]
+                print('{}:\n{}\n'.format(check_name, check.__doc__))
+        else:
+            print("Available checks:", ','.join(check_list))
+        sys.exit(0)
 
     checks = []
     for check in args.checks.split(','):


### PR DESCRIPTION
Add a verbose mode

When given the "list_checks" option, if the verbose flag is set, checks will be pretty(er) printed with details regarding what the checks are intended to accomplish (taken from the docstring).

When in verbose mode, nclint will now print out the filename and check name for each failed check.

Fixes #4